### PR TITLE
enable to specify library URL in an options page

### DIFF
--- a/prod/manifest.json
+++ b/prod/manifest.json
@@ -17,5 +17,14 @@
       "js": ["js/converter.js"],
       "run_at": "document_start"
     }
-  ]
+  ],
+
+  "permissions": [
+    "storage"
+  ],
+
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": false
+  }
 }

--- a/prod/options/options.css
+++ b/prod/options/options.css
@@ -1,0 +1,3 @@
+label, input {
+  display: block;
+}

--- a/prod/options/options.html
+++ b/prod/options/options.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <link rel='stylesheet' href='./options.css'>
+    <title>Canvas Masao Converter Options</title>
+</head>
+<body>
+<section>
+    <h1>Library URL</h1>
+    <p>
+        <label for="url_fx">Canvas Masao FX</label>
+        <input type="text" id="url_fx" size="64">
+    </p>
+    <p>
+        <label for="url_kani2">Canvas Masao FX (MasaoKani2)</label>
+        <input type="text" id="url_kani2" size="64">
+    </p>
+    <p>
+        <label for="url_v28">Canvas Masao v28</label>
+        <input type="text" id="url_v28" size="64">
+    </p>
+</section>
+
+<div id="status"></div>
+<button id="save">Save</button>
+<button id="reset">Revert to default</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/prod/options/options.js
+++ b/prod/options/options.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const default_urls = {
+	fx: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao.js",
+	kani2: "https://Ryo-9399.github.io/mc_canvas/Outputs/MasaoKani2.js",
+	v28: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao_v28.js"
+};
+
+// save options to chrome.storage
+function saveOptions() {
+	const url_fx = document.getElementById("url_fx").value;
+	const url_kani2 = document.getElementById("url_kani2").value;
+	const url_v28 = document.getElementById("url_v28").value;
+	chrome.storage.sync.set({url_fx, url_kani2, url_v28}, () => {
+		// Update status to let user know options were saved.
+		const status = document.getElementById('status');
+		status.textContent = 'Options saved.';
+		setTimeout(function () {
+			status.textContent = '';
+		}, 750);
+	})
+}
+
+// restore options and fill input form
+function restoreOptions() {
+	chrome.storage.sync.get({url_fx: default_urls.fx, url_kani2: default_urls.kani2, url_v28: default_urls.v28}, (items) => {
+		document.getElementById("url_fx").value = items.url_fx;
+		document.getElementById("url_kani2").value = items.url_kani2;
+		document.getElementById("url_v28").value = items.url_v28;
+	});
+}
+
+// reset all options to default and save them
+function revertOptionsToDefault() {
+	document.getElementById("url_fx").value = default_urls.fx;
+	document.getElementById("url_kani2").value = default_urls.kani2;
+	document.getElementById("url_v28").value = default_urls.v28;
+	const status = document.getElementById('status');
+	status.textContent = 'default options loaded (not yet be saved).';
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);
+document.getElementById('reset').addEventListener('click', revertOptionsToDefault);

--- a/prod/options/options.js
+++ b/prod/options/options.js
@@ -1,9 +1,9 @@
 "use strict";
 
 const default_urls = {
-	fx: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao.js",
-	kani2: "https://Ryo-9399.github.io/mc_canvas/Outputs/MasaoKani2.js",
-	v28: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao_v28.js"
+  url_fx: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao.js",
+  url_kani2: "https://Ryo-9399.github.io/mc_canvas/Outputs/MasaoKani2.js",
+  url_v28: "https://Ryo-9399.github.io/mc_canvas/Outputs/CanvasMasao_v28.js"
 };
 
 // save options to chrome.storage
@@ -23,7 +23,7 @@ function saveOptions() {
 
 // restore options and fill input form
 function restoreOptions() {
-	chrome.storage.sync.get({url_fx: default_urls.fx, url_kani2: default_urls.kani2, url_v28: default_urls.v28}, (items) => {
+	chrome.storage.sync.get(default_urls, (items) => {
 		document.getElementById("url_fx").value = items.url_fx;
 		document.getElementById("url_kani2").value = items.url_kani2;
 		document.getElementById("url_v28").value = items.url_v28;
@@ -32,9 +32,9 @@ function restoreOptions() {
 
 // reset all options to default and save them
 function revertOptionsToDefault() {
-	document.getElementById("url_fx").value = default_urls.fx;
-	document.getElementById("url_kani2").value = default_urls.kani2;
-	document.getElementById("url_v28").value = default_urls.v28;
+	document.getElementById("url_fx").value = default_urls.url_fx;
+	document.getElementById("url_kani2").value = default_urls.url_kani2;
+	document.getElementById("url_v28").value = default_urls.url_v28;
 	const status = document.getElementById('status');
 	status.textContent = 'default options loaded (not yet be saved).';
 }


### PR DESCRIPTION
this fix enables to edit options at chrome://extensions and set URLs of the locations of canvas masao javascript file.